### PR TITLE
Add grunt task "peerDepInstall" to pre publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ cache:
   directories:
   - node_modules
 install:
-- travis_retry npm install grunt-cli $(node -e "var deps = require('./package.json').peerDependencies;
-  for(var name in deps) process.stdout.write(name + '@' + deps[name] + ' ');")
+- travis_retry npm install grunt-cli
 - travis_retry npm install
 script:
 - grunt

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/dojo/has.git"
   },
   "scripts": {
-    "prepublish": "grunt dist",
+    "prepublish": "grunt peerDepInstall dist",
     "test": "grunt test"
   },
   "typings": "./dist/umd/dojo-has.d.ts",


### PR DESCRIPTION
Adds `peerDepInstall` grunt task to the `prepublish` node script and removes the travis script used to install peer deps.