### PR TITLE
Update to @types

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,24 +23,17 @@
     "test": "grunt test"
   },
   "devDependencies": {
+    "@types/chai": "3.4.*",
+    "@types/glob": "5.0.*",
+    "@types/grunt": "0.4.*",
+    "@types/sinon": "1.16.*",
     "codecov.io": "0.1.6",
     "dojo-loader": ">=2.0.0-beta.7",
-    "dts-generator": "~1.7.0",
-    "glob": "^7.0.3",
     "grunt": "~1.0.1",
-    "grunt-contrib-clean": "^1.0.0",
-    "grunt-contrib-copy": "^1.0.0",
-    "grunt-contrib-watch": "^1.0.0",
-    "grunt-dojo2": ">=2.0.0-beta.7",
-    "grunt-text-replace": "^0.4.0",
-    "grunt-ts": "^5.5.1",
-    "grunt-tslint": "^3.1.0",
-    "grunt-typings": ">=0.1.5",
+    "grunt-dojo2": ">=2.0.0-beta.16",
     "intern": "^3.2.3",
-    "istanbul": "^0.4.3",
-    "remap-istanbul": "^0.6.4",
     "sinon": "^1.17.4",
-    "tslint": "next",
-    "typescript": "2.0.2"
+    "tslint": "^3.11.0",
+    "typescript": "~2.0.3"
   }
 }

--- a/tests/unit/has.ts
+++ b/tests/unit/has.ts
@@ -191,22 +191,22 @@ registerSuite({
 		'both feature and no-feature modules provided'() {
 			hasAdd('abc', true);
 			hasAdd('def', false);
-			assert.strictEqual(hasNormalize('abc?intern:intern!object', require.toAbsMid), 'intern/main');
-			assert.strictEqual(hasNormalize('def?intern:intern!object', require.toAbsMid), 'intern!object');
+			assert.strictEqual(hasNormalize('abc?intern:intern!object', (<any> require).toAbsMid), 'intern/main');
+			assert.strictEqual(hasNormalize('def?intern:intern!object', (<any> require).toAbsMid), 'intern!object');
 		},
 
 		'only feature module provided'() {
 			hasAdd('abc', true);
 			hasAdd('def', false);
-			assert.strictEqual(hasNormalize('abc?intern', require.toAbsMid), 'intern/main');
-			assert.isUndefined(hasNormalize('def?intern', require.toAbsMid));
+			assert.strictEqual(hasNormalize('abc?intern', (<any> require).toAbsMid), 'intern/main');
+			assert.isUndefined(hasNormalize('def?intern', (<any> require).toAbsMid));
 		},
 
 		'only no-feature module provided'() {
 			hasAdd('abc', true);
 			hasAdd('def', false);
-			assert.isNull(hasNormalize('abc?:intern', require.toAbsMid));
-			assert.strictEqual(hasNormalize('def?:intern', require.toAbsMid), 'intern/main');
+			assert.isNull(hasNormalize('abc?:intern', (<any> require).toAbsMid));
+			assert.strictEqual(hasNormalize('def?:intern', (<any> require).toAbsMid), 'intern/main');
 		},
 
 		'chained ternary test'() {
@@ -217,9 +217,9 @@ registerSuite({
 			hasAdd('abc', true);
 			hasAdd('def', false);
 
-			const actual1 = hasNormalize('abc?def?one:two:three', require.toAbsMid);
-			const actual2 = hasNormalize('abc?abc?one:two:three', require.toAbsMid);
-			const actual3 = hasNormalize('def?abc?one:two:three', require.toAbsMid);
+			const actual1 = hasNormalize('abc?def?one:two:three', (<any> require).toAbsMid);
+			const actual2 = hasNormalize('abc?abc?one:two:three', (<any> require).toAbsMid);
+			const actual3 = hasNormalize('def?abc?one:two:three', (<any> require).toAbsMid);
 
 			assert.strictEqual(expected1, actual1);
 			assert.strictEqual(expected2, actual2);
@@ -233,8 +233,8 @@ registerSuite({
 			hasAdd('abc', true);
 			hasAdd('def', false);
 
-			const actualHasFeatureModule = hasNormalize('abc?intern:intern!object', require.toAbsMid);
-			const actualHasNoFeatureModule = hasNormalize('def?intern:intern!object', require.toAbsMid);
+			const actualHasFeatureModule = hasNormalize('abc?intern:intern!object', (<any> require).toAbsMid);
+			const actualHasNoFeatureModule = hasNormalize('def?intern:intern!object', (<any> require).toAbsMid);
 
 			assert.strictEqual(expectedHasFeatureModule, actualHasFeatureModule);
 			assert.strictEqual(expectedHasNoFeatureModule, actualHasNoFeatureModule);
@@ -269,7 +269,7 @@ registerSuite({
 			const requireSpy = sinon.spy(require);
 			const loadedStub = sinon.stub();
 
-			hasLoad(<any> null, require, loadedStub);
+			hasLoad(<any> null, <any> require, loadedStub);
 			assert.isTrue(loadedStub.calledOnce);
 			assert.isFalse(requireSpy.calledOnce);
 		}
@@ -289,7 +289,7 @@ registerSuite({
 	'static has features': {
 		'staticFeatures object'(this: any) {
 			const dfd = this.async();
-			require.undef('src/has');
+			(<any> require).undef('src/has');
 			globalScope.DojoHasEnvironment = {
 				staticFeatures: {
 					'foo': 1,
@@ -297,7 +297,7 @@ registerSuite({
 					'baz': false
 				}
 			};
-			require([ 'src/has' ], dfd.callback((mod: { default: typeof has }) => {
+			(<any> require)([ 'src/has' ], dfd.callback((mod: { default: typeof has }) => {
 				const h = mod.default;
 				assert(!('DojoHasEnvironment' in globalScope));
 				assert.strictEqual(h('foo'), 1);
@@ -307,7 +307,7 @@ registerSuite({
 		},
 		'staticFeatures function'(this: any) {
 			const dfd = this.async();
-			require.undef('src/has');
+			(<any> require).undef('src/has');
 			globalScope.DojoHasEnvironment = {
 				staticFeatures: function () {
 					return {
@@ -317,7 +317,7 @@ registerSuite({
 					};
 				}
 			};
-			require([ 'src/has' ], dfd.callback((mod: { default: typeof has }) => {
+			(<any> require)([ 'src/has' ], dfd.callback((mod: { default: typeof has }) => {
 				const h = mod.default;
 				assert(!('DojoHasEnvironment' in globalScope));
 				assert.strictEqual(h('foo'), 1);

--- a/typings.json
+++ b/typings.json
@@ -1,18 +1,10 @@
 {
 	"name": "dojo-has",
-	"devDependencies": {
-		"chai": "registry:npm/chai#3.5.0+20160415060238",
-		"glob": "registry:npm/glob#6.0.0+20160211003958",
-		"sinon": "registry:npm/sinon#1.16.0+20160427193336"
-	},
 	"globalDevDependencies": {
 		"digdug": "github:dojo/typings/custom/digdug/digdug.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
-		"dojo-loader": "npm:dojo-loader",
 		"dojo2": "github:dojo/typings/custom/dojo2/dojo.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
 		"dojo2-dev": "github:dojo/typings/custom/dev/dev.d.ts#288d3a9868194f0e1ad6687371dffd1d96cb39a1",
-		"gruntjs": "registry:dt/gruntjs#0.4.0+20160316171810",
-		"intern": "github:dojo/typings/custom/intern/intern.d.ts#92fcf688c0982c1107fca278de52e4bfe23bd8af",
-		"leadfoot": "github:dojo/typings/custom/leadfoot/leadfoot.d.ts#8f3dfe6cafd04dfa78068785551552a5cfd88db1",
-		"node": "github:dojo/typings/custom/node/node.d.ts#a62873258aa1deed48f9882c193c335436100d4b"
+		"intern": "github:dojo/typings/custom/intern/intern.d.ts#122b1902bdbdb7b94bdee35bbc27bc6747e1979d",
+		"leadfoot": "github:dojo/typings/custom/leadfoot/leadfoot.d.ts#a62873258aa1deed48f9882c193c335436100d4b"
 	}
 }


### PR DESCRIPTION
Refs dojo/meta#62

Because we make heave use of the AMD `require` in the tests, we have to cast it as `<any>` because it gets magically typed as the `NodeRequire`.