### PR TITLE
Add "has('debug')" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ used to enable a developer to express other features.  The flags though that are
 
 |Feature Flag|Description|
 |------------|-----------|
+|`debug`|Provides a way to code path for code that is only usable when debugging or providing enhanced diagnostics that are not desired in a *production* build.  Defaults to `true` but should be configured statically as `false` in production builds.|
 |`host-browser`|Determines if the current environment contains a `window` and `document` object in the global context, therefore it being generally safe to assume the code is running in a browser environment.|
 |`host-node`|Attempts to detect if the environment appears to be a node environment.|
 

--- a/src/has.ts
+++ b/src/has.ts
@@ -215,7 +215,14 @@ export default function has(feature: string): FeatureTestResult {
  */
 
 /* Evironments */
+
+/* Used as a value to provide a debug only code path */
+add('debug', true);
+
+/* Detects if the environment is "browser like" */
 add('host-browser', typeof document !== 'undefined' && typeof location !== 'undefined');
+
+/* Detects if the enviornment appears to be NodeJS */
 add('host-node', function () {
 	if (typeof process === 'object' && process.versions && process.versions.node) {
 		return process.versions.node;

--- a/tests/unit/has.ts
+++ b/tests/unit/has.ts
@@ -331,13 +331,13 @@ registerSuite({
 		},
 		'can override run-time defined features'(this: any) {
 			const dfd = this.async();
-			require.undef('src/has');
+			(<any> require).undef('src/has');
 			globalScope.DojoHasEnvironment = {
 				staticFeatures: {
 					debug: false
 				}
 			};
-			require([ 'src/has' ], dfd.callback((mod: { default: typeof has, add: typeof hasAdd }) => {
+			(<any> require)([ 'src/has' ], dfd.callback((mod: { default: typeof has, add: typeof hasAdd }) => {
 				const h = mod.default;
 				const hAdd = mod.add;
 				assert.isFalse(h('debug'), 'Static features override "add()"');

--- a/tests/unit/has.ts
+++ b/tests/unit/has.ts
@@ -276,6 +276,10 @@ registerSuite({
 	},
 
 	'built in feature flags': {
+		'debug'() {
+			assert.isTrue(hasExists('debug'));
+			assert.isTrue(has('debug'), 'Debug should default to true');
+		},
 		'host-browser'() {
 			assert.isTrue(hasExists('host-browser'));
 			assert.strictEqual(has('host-browser'), typeof document !== 'undefined' && typeof location !== 'undefined');
@@ -323,6 +327,22 @@ registerSuite({
 				assert.strictEqual(h('foo'), 1);
 				assert.strictEqual(h('bar'), 'bar');
 				assert.isFalse(h('baz'));
+			}));
+		},
+		'can override run-time defined features'(this: any) {
+			const dfd = this.async();
+			require.undef('src/has');
+			globalScope.DojoHasEnvironment = {
+				staticFeatures: {
+					debug: false
+				}
+			};
+			require([ 'src/has' ], dfd.callback((mod: { default: typeof has, add: typeof hasAdd }) => {
+				const h = mod.default;
+				const hAdd = mod.add;
+				assert.isFalse(h('debug'), 'Static features override "add()"');
+				hAdd('debug', true, true);
+				assert.isFalse(h('debug'), 'Static features cannot be overwritten');
 			}));
 		}
 	}


### PR DESCRIPTION
**Type:** feature

**Description:** 

This adds a feature named `debug` which defaults to `true`.  It allows for code paths for code that should only be executed in a *debug* mode, like providing additional warnings or collecting or emitting diagnostic information.

It is intended that for *production* builds, this will be disabled by defining a static feature to set the value to `false`.

This PR also includes tests to validate that features that are defined at run-time can actually be overridden by the definition of a static feature, which was not a test that was being done.

**Related Issue:** #22 
