### PR TITLE
Adding thenable to add, issue #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ used to enable a developer to express other features.  The flags though that are
 ### Adding a Feature Test/Feature Detection
 
 The main module of the package exports a function named `add()` which allows the addition of features flags.  The feature
-tests can be expressed as a static value, or as a function which will be lazily evaluated when the feature flag is first
-requested from `has()`.  Once evaluated, the value is cached.
+tests can be expressed as a static value, a function which will be lazily evaluated when the feature flag is first
+requested from `has()`, or a thenable (an object with a `then` method, like a Promise).  Once evaluated, the value is cached.
 
 An example of adding a feature:
 
@@ -70,6 +70,10 @@ add('my-lazy-feature', () => {
 	/* will not be called yet */
 	return true;
 });
+add('my-promise', new Promise((resolve) => {
+	// start some asynchronous task
+	resolve(true);
+}));
 
 if (has('my-lazy-feature')) { /* feature function called here */
 	/* do something */
@@ -92,6 +96,9 @@ if (!exists('my-feature')) {
 	add('my-feature', false);
 }
 ```
+
+Note that if a thenable is passed to `add`, `exists` and `has` will return `false` until the thenable is resolved and a
+proper value can be returned.
 
 ### Conditional Module Loading
 

--- a/src/has.ts
+++ b/src/has.ts
@@ -10,6 +10,15 @@ export type FeatureTestResult = boolean | string | number | undefined;
  */
 export type FeatureTest = () => FeatureTestResult;
 
+export type FeatureTestThenable = {
+	then<U>(onFulfilled?: (value: FeatureTestResult) => U | FeatureTestThenable, onRejected?: (error: any) => U | FeatureTestThenable): FeatureTestThenable;
+	then<U>(onFulfilled?: (value: FeatureTestResult) => U | FeatureTestThenable, onRejected?: (error: any) => void): FeatureTestThenable;
+};
+
+function isFeatureTestThenable(o: any): o is FeatureTestThenable {
+	return o && o.then;
+}
+
 /**
  * A cache of results of feature tests
  */
@@ -19,6 +28,12 @@ export const testCache: { [feature: string]: FeatureTestResult } = {};
  * A cache of the un-resolved feature tests
  */
 export const testFunctions: { [feature: string]: FeatureTest } = {};
+
+/**
+ * A cache of unresolved thenables (probably promises)
+ * @type {{}}
+ */
+export const testThenables: { [feature: string]: FeatureTestThenable} = {};
 
 export interface StaticHasFeatures {
 	[ feature: string ]: FeatureTestResult;
@@ -173,7 +188,7 @@ export function exists(feature: string): boolean {
  * @param value the value reported of the feature, or a function that will be executed once on first test
  * @param overwrite if an existing value should be overwritten. Defaults to false.
  */
-export function add(feature: string, value: FeatureTest | FeatureTestResult, overwrite: boolean = false): void {
+export function add(feature: string, value: FeatureTest | FeatureTestResult | FeatureTestThenable, overwrite: boolean = false): void {
 	const normalizedFeature = feature.toLowerCase();
 
 	if (exists(normalizedFeature) && !overwrite && !(normalizedFeature in staticCache)) {
@@ -182,6 +197,14 @@ export function add(feature: string, value: FeatureTest | FeatureTestResult, ove
 
 	if (typeof value === 'function') {
 		testFunctions[normalizedFeature] = value;
+	}
+	else if (isFeatureTestThenable(value)) {
+		testThenables[ feature ] = value.then((resolvedValue: FeatureTestResult) => {
+			testCache [ feature ] = resolvedValue;
+			delete testThenables [ feature ];
+		}, () => {
+			delete testThenables [ feature ];
+		});
 	}
 	else {
 		testCache[normalizedFeature] = value;
@@ -208,6 +231,9 @@ export default function has(feature: string): FeatureTestResult {
 	}
 	else if (normalizedFeature in testCache) {
 		result = testCache[normalizedFeature];
+	}
+	else if (feature in testThenables) {
+		return false;
 	}
 	else {
 		throw new TypeError(`Attempt to detect unregistered has feature "${feature}"`);

--- a/src/has.ts
+++ b/src/has.ts
@@ -15,8 +15,8 @@ export type FeatureTestThenable = {
 	then<U>(onFulfilled?: (value: FeatureTestResult) => U | FeatureTestThenable, onRejected?: (error: any) => void): FeatureTestThenable;
 };
 
-function isFeatureTestThenable(o: any): o is FeatureTestThenable {
-	return o && o.then;
+function isFeatureTestThenable(value: any): value is FeatureTestThenable {
+	return value && value.then;
 }
 
 /**
@@ -33,7 +33,7 @@ export const testFunctions: { [feature: string]: FeatureTest } = {};
  * A cache of unresolved thenables (probably promises)
  * @type {{}}
  */
-export const testThenables: { [feature: string]: FeatureTestThenable} = {};
+const testThenables: { [feature: string]: FeatureTestThenable} = {};
 
 export interface StaticHasFeatures {
 	[ feature: string ]: FeatureTestResult;

--- a/tests/unit/has.ts
+++ b/tests/unit/has.ts
@@ -140,6 +140,50 @@ registerSuite({
 			}, TypeError, 'exists and overwrite not true');
 		},
 
+		'works with thenable'(this: any) {
+			const dfd = this.async();
+
+			const thenable = {
+				then(resolve: (_: number) => void) {
+					setTimeout(() => {
+						resolve(5);
+					}, 10);
+
+					return thenable;
+				}
+			};
+
+			hasAdd('thenable', thenable);
+			assert.isFalse(has('thenable'));
+
+			setTimeout(dfd.callback(() => {
+				assert.equal(has('thenable'), 5);
+			}), 100);
+		},
+
+		'failed thenable removes itself from cache'(this: any) {
+			const dfd = this.async();
+
+			const thenable = {
+				then(_: (_: number) => void, reject: (_: Error) => void) {
+					setTimeout(() => {
+						reject(new Error('test error'));
+					}, 10);
+
+					return thenable;
+				}
+			};
+
+			hasAdd('thenable', thenable);
+			assert.isFalse(has('thenable'));
+
+			setTimeout(dfd.callback(() => {
+				assert.throws(() => {
+					has('thenable');
+				});
+			}), 100);
+		},
+
 		overwrite: {
 			'value with value'() {
 				hasAdd(feature, 'old');
@@ -189,6 +233,27 @@ registerSuite({
 		'null test value counts as being defined'() {
 			hasAdd(feature, <any> null);
 			assert.isTrue(hasExists(feature));
+		},
+
+		'exists with thenabale'(this: any) {
+			const dfd = this.async();
+
+			const thenable = {
+				then(resolve: (_: number) => void) {
+					setTimeout(() => {
+						resolve(5);
+					}, 10);
+
+					return thenable;
+				}
+			};
+
+			hasAdd('thenable', thenable);
+			assert.isFalse(hasExists('thenable'));
+
+			setTimeout(dfd.callback(() => {
+				assert.isTrue(hasExists('thenable'));
+			}), 100);
 		},
 
 		'case should not matter'() {


### PR DESCRIPTION
<!--
Thank you for Contributing to Dojo 2.

Please make sure you have read our Contributing Guidelines
available at: https://github.com/dojo/meta/blob/master/CONTRIBUTING.md
before submitting a PR.

-->

**Type:** feature

**Description:** 

Adding support for passing in thenables and other promises into `add`.  Passing a thenable will cause `has` and `exists` to both return `false` until the thenable resolves.

Example,

```ts
add('async', new Promise(resolve => setTimeout(() => resolve(true), 10));
has('async'); // false

// wait a bit

has('async'); // true
```

**Related Issue:** #2

Please review this checklist before submitting your PR:

* [x] There is a related issue
* [x] All contributors have signed a CLA
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] The code passes the CI tests
* [x] Unit or Functional tests are included in the PR
* [x] The PR increases or maintains the overall unit test coverage percentage
* [x] The code is ready to be merged

