### PR TITLE
Update to Intern 3.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,8 @@ env:
   - SAUCE_ACCESS_KEY: e92610e3-834e-4bec-a3b5-6f7b9d874601
   - BROWSERSTACK_USERNAME: dtktestaccount1
   - BROWSERSTACK_ACCESS_KEY: mG2qbEFJCZY2qLsM7yfx
-cache:
-  directories:
-  - node_modules
 install:
-- travis_retry npm install grunt-cli $(node -e "var deps = require('./package.json').peerDependencies;
-  for(var name in deps) process.stdout.write(name + '@' + deps[name] + ' ');")
+- travis_retry npm install grunt-cli
 - travis_retry npm install
 script:
 - grunt
@@ -21,6 +17,7 @@ script:
 - grunt intern:saucelabs --combined
 - grunt remapIstanbul:ci
 - grunt uploadCoverage
+- grunt dist
 notifications:
   slack:
     secure: mys3cAqs3gJ7HxLVhXMScDOZXCSdLsuVeMpAQXJ92/LxcMIS0wtIwaTqDox/n/U4tkhNEb1R3gJyEXBxeCu117umxX/aVNsR9HuZTXC+SjECwlPaan/qZkw7hSwqfwhEiGW4A8FGCA5OD+sq20ARpLZ718JrqzIYfSotpuJSHVg5OlfaCQIE3MdlpGjwJ0ZCxpsrVXVTmgFtxCmv8qmV24DcTnEQFmiXJftHhgi/npU/XdPAkdnjbS//iiWxV1vHiQagt0sVW3hxma5jzOaSHkiQQsJGNYCDCdLhzma3DDJoDS4sfznPMT08AQfSEzQiFhDIhNfJYVSbYjNbUq1O3xTSq83Lvdc/hQ1bLsYk7ZFqhWpRprijS6pYe/yp0TwlruzqTa5/a3qduCnc+ooMg72m1NxpUHiZG1NhD/IVz+ycEVt8P6yQpytXUsGiRGecmFJW0A0BrfrVcg7Ekwsr6Rmzxh4uKyXuOW7zTT3tn4CM1Q2fBZNXnQ9RlU7AIS3hiBIkv2SS89fuUrgTMEL9qDXF7zB4E9nc4mwvBM2YLHsdgiF+WSA1EERLxsYo9Ea3vtOUyjoi9A5EGKwHq7VAYEbEQfWYoDtIepSMmWCGjtDr3KI8oMdojkZdY0CrG7xGgruOX5QQQY6BEKTcgpW+ccVqjR5zB0Q8IZ04qhC5F+0=

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "dojo-has",
   "version": "2.0.0-pre",
   "description": "A feature detection library",
+  "engines": {
+    "node": "~6.5.0 || ~7.0.0",
+    "npm": "~3.10.0"
+  },
   "homepage": "http://dojotoolkit.org",
   "bugs": {
     "url": "https://github.com/dojo/has/issues"
@@ -23,17 +27,16 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "@types/chai": "3.4.*",
-    "@types/glob": "5.0.*",
-    "@types/grunt": "0.4.*",
-    "@types/sinon": "1.16.*",
-    "codecov.io": "0.1.6",
+    "@types/chai": "~3.4.0",
+    "@types/glob": "~5.0.0",
+    "@types/grunt": "~0.4.0",
+    "@types/sinon": "~1.16.0",
     "dojo-loader": ">=2.0.0-beta.7",
     "grunt": "~1.0.1",
-    "grunt-dojo2": ">=2.0.0-beta.16",
-    "intern": "3.3.2",
+    "grunt-dojo2": ">=2.0.0-beta.21",
+    "intern": "~3.4.1",
     "sinon": "^1.17.4",
-    "tslint": "^3.11.0",
-    "typescript": "~2.0.3"
+    "tslint": "^3.15.0",
+    "typescript": "~2.0.10"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,14 +3,14 @@
 	"compilerOptions": {
 		"declaration": false,
 		"module": "umd",
+		"moduleResolution": "node",
 		"noImplicitAny": true,
+		"noImplicitThis": true,
 		"outDir": "_build/",
 		"removeComments": false,
 		"sourceMap": true,
-		"target": "es5",
-		"moduleResolution": "node",
 		"strictNullChecks": true,
-		"noImplicitThis": true
+		"target": "es5"
 	},
 	"include": [
 		"./typings/index.d.ts",

--- a/typings.json
+++ b/typings.json
@@ -1,10 +1,6 @@
 {
 	"name": "dojo-has",
 	"globalDevDependencies": {
-		"digdug": "github:dojo/typings/custom/digdug/digdug.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
-		"dojo2": "github:dojo/typings/custom/dojo2/dojo.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
-		"dojo2-dev": "github:dojo/typings/custom/dev/dev.d.ts#288d3a9868194f0e1ad6687371dffd1d96cb39a1",
-		"intern": "github:dojo/typings/custom/intern/intern.d.ts#122b1902bdbdb7b94bdee35bbc27bc6747e1979d",
-		"leadfoot": "github:dojo/typings/custom/leadfoot/leadfoot.d.ts#a62873258aa1deed48f9882c193c335436100d4b"
+		"dojo2-dev": "github:dojo/typings/custom/dev/dev.d.ts#288d3a9868194f0e1ad6687371dffd1d96cb39a1"
 	}
 }


### PR DESCRIPTION
**Type:** bug

**Description:** 

This updates the package meta data to make it possible to use Intern ~3.4.1.  It also removes the `node_cache` from the `.travis.yml`, adds the `"engines"` property to the `package.json`, add a `grunt dist` to the CI, removes the unnecessary peer install from the CI, and migrates to the agreed semver for the `@types` packages.

**Related Issue:** dojo/meta#117

Please review this checklist before submitting your PR:

* [X] There is a related issue
* [X] All contributors have signed a CLA
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] The code passes the CI tests
* [ ] Unit or Functional tests are included in the PR
* [ ] The PR increases or maintains the overall unit test coverage percentage
* [ ] The code is ready to be merged

