### PR TITLE
remove the tslint prettier plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,9 @@
       "dev": true
     },
     "@dojo/interfaces": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.2.0.tgz",
-      "integrity": "sha512-sgqHsKraTjKDoLfWece/E/ip29CsV3z+vEDSIzuBSWtXDEau6/pDRhbhuSnxjBB1bvvB8Drn93xWkO+PqqQ0Dg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.2.1.tgz",
+      "integrity": "sha512-/bIJJb9q02MxSlfA9G3n6AMTlD80fDx7qDRss/8HxeJ26ix/F/tCnX521c3XrWm/HOBEWp7GiRX5E0hQdIuCNw==",
       "dev": true,
       "requires": {
         "@types/yargs": "8.0.3"
@@ -50,7 +50,7 @@
       "requires": {
         "@dojo/core": "0.3.0",
         "@dojo/has": "0.1.1",
-        "@dojo/interfaces": "0.2.0",
+        "@dojo/interfaces": "0.2.1",
         "@dojo/shim": "0.2.3",
         "decompress": "4.2.0",
         "semver": "5.4.1",
@@ -65,7 +65,7 @@
       "requires": {
         "@dojo/core": "0.3.0",
         "@dojo/has": "0.1.1",
-        "@dojo/interfaces": "0.2.0",
+        "@dojo/interfaces": "0.2.1",
         "@dojo/shim": "0.2.3",
         "@types/jszip": "0.0.33",
         "jszip": "3.1.5",
@@ -73,9 +73,9 @@
       }
     },
     "@types/babel-types": {
-      "version": "6.25.2",
-      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-6.25.2.tgz",
-      "integrity": "sha512-+3bMuktcY4a70a0KZc8aPJlEOArPuAKQYHU5ErjkOqGJdx8xuEEVK6nWogqigBOJ8nKPxRpyCUDTCPmZ3bUxGA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.0.tgz",
+      "integrity": "sha512-PyWcbX0W4r4GcgXLI0Vu4jyJ/Erueo3PwjgvQcOmWAOBW0ObhzBBciEX+sHvjkNE0umI6nqD192FDKvYZTL91A==",
       "dev": true
     },
     "@types/benchmark": {
@@ -91,7 +91,7 @@
       "dev": true,
       "requires": {
         "@types/express": "4.0.39",
-        "@types/node": "8.5.1"
+        "@types/node": "8.5.5"
       }
     },
     "@types/chai": {
@@ -106,7 +106,7 @@
       "integrity": "sha512-F9OalGhk60p/DnACfa1SWtmVTMni0+w9t/qfb5Bu7CsurkEjZFN7Z+ii/VGmYpaViPz7o3tBahRQae9O7skFlQ==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.1"
+        "@types/node": "8.5.5"
       }
     },
     "@types/diff": {
@@ -128,17 +128,17 @@
       "dev": true,
       "requires": {
         "@types/body-parser": "1.16.8",
-        "@types/express-serve-static-core": "4.0.57",
+        "@types/express-serve-static-core": "4.11.0",
         "@types/serve-static": "1.13.1"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.0.57",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.57.tgz",
-      "integrity": "sha512-QLAHjdLwEICm3thVbXSKRoisjfgMVI4xJH/HU8F385BR2HI7PmM6ax4ELXf8Du6sLmSpySXMYaI+xc//oQ/IFw==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.11.0.tgz",
+      "integrity": "sha512-hOi1QNb+4G+UjDt6CEJ6MjXHy+XceY7AxIa28U9HgJ80C+3gIbj7h5dJNxOI7PU3DO1LIhGP5Bs47Dbf5l8+MA==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.1"
+        "@types/node": "8.5.5"
       }
     },
     "@types/fs-extra": {
@@ -147,7 +147,7 @@
       "integrity": "sha1-qHGcQXsIDAEtNJeyjiKKwJdF/fI=",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.1"
+        "@types/node": "8.5.5"
       }
     },
     "@types/glob": {
@@ -158,7 +158,7 @@
       "requires": {
         "@types/events": "1.1.0",
         "@types/minimatch": "3.0.2",
-        "@types/node": "8.5.1"
+        "@types/node": "8.5.5"
       }
     },
     "@types/grunt": {
@@ -167,7 +167,7 @@
       "integrity": "sha512-fKrWJ+uFq9j3tP2RLm9cY7Z50LhhPnSHQCliCZP5lPAWC7TydnU+BcLR0KQIHe9Gbn1oGfkRIq3u56MNCC1qyw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.1"
+        "@types/node": "8.5.5"
       }
     },
     "@types/handlebars": {
@@ -201,14 +201,22 @@
       "dev": true
     },
     "@types/istanbul-lib-instrument": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.0.tgz",
-      "integrity": "sha512-BWj7zRtwVU5KzuYL/zNuVoSvYWIpT02smNMpQwQbJjwEyITEGSKsxVIT4b2bzXCWFMq76ss0sdY/5yw3NwTlIA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.1.tgz",
+      "integrity": "sha512-Ll2qAzv7NItqVliZZ8OMAgAvGstddK2995/7X5YPU84lD3CFnqDfP4sTu5Q1GKReh5Ttw3shKR2e3Fe6Xo0C7A==",
       "dev": true,
       "requires": {
-        "@types/babel-types": "6.25.2",
+        "@types/babel-types": "7.0.0",
         "@types/istanbul-lib-coverage": "1.1.0",
-        "@types/source-map": "0.1.29"
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "@types/istanbul-lib-report": {
@@ -221,13 +229,21 @@
       }
     },
     "@types/istanbul-lib-source-maps": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.0.tgz",
-      "integrity": "sha512-GxjyOSIZC/HETEo61MOjM72qdZH0F9UwfuXCKhmgqhVC7PSjE61BU2I/2eZwQ43+kSdkxKvnOBqqNZi1HHHNEA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
+      "integrity": "sha512-K0IvmTFbI2GjLG0O4AOLPV2hFItE5Bg/TY41IBZIThhLhYthJc3VjpZpM8/sIaIVtnQcX8b2k3muPDvsvhk+Fg==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "1.1.0",
-        "@types/source-map": "0.1.29"
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "@types/istanbul-reports": {
@@ -277,9 +293,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.1.tgz",
-      "integrity": "sha512-SrmAO+NhnsuG/6TychSl2VdxBZiw/d6V+8j+DFo8O3PwFi+QeYXWHhAw+b170aSc6zYab6/PjEWRZHIDN9mNUw==",
+      "version": "8.5.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.5.tgz",
+      "integrity": "sha512-JRnfoh0Ll4ElmIXKxbUfcOodkGvcNHljct6mO1X9hE/mlrMzAx0hYCLAD7sgT53YAY1HdlpzUcV0CkmDqUqTuA==",
       "dev": true
     },
     "@types/platform": {
@@ -294,7 +310,7 @@
       "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.1"
+        "@types/node": "8.5.5"
       }
     },
     "@types/serve-static": {
@@ -303,7 +319,7 @@
       "integrity": "sha512-jDMH+3BQPtvqZVIcsH700Dfi8Q3MIcEx16g/VdxjoqiGR/NntekB10xdBpirMKnPe9z2C5cBmL0vte0YttOr3Q==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "4.0.57",
+        "@types/express-serve-static-core": "4.11.0",
         "@types/mime": "2.0.0"
       }
     },
@@ -319,7 +335,7 @@
       "integrity": "sha1-32E73biCJe0JzlyDX2INyq8VXms=",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.1"
+        "@types/node": "8.5.5"
       }
     },
     "@types/sinon": {
@@ -346,7 +362,7 @@
       "integrity": "sha512-+30f9gcx24GZRD9EqqiQM+I5pRf/MJiJoEqp2X62QRwfEjdqyn9mPmjxZAEXBUVunWotE5qkadIPqf2MMcDYNw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.1"
+        "@types/node": "8.5.5"
       }
     },
     "@types/yargs": {
@@ -625,7 +641,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000783",
+        "caniuse-db": "1.0.30000787",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -977,8 +993,8 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000783",
-        "electron-to-chromium": "1.3.28"
+        "caniuse-db": "1.0.30000787",
+        "electron-to-chromium": "1.3.30"
       }
     },
     "buffer": {
@@ -1041,15 +1057,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000783",
+        "caniuse-db": "1.0.30000787",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000783",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000783.tgz",
-      "integrity": "sha1-FrMNRyZqT1FcxprgMWtnDJYDzb4=",
+      "version": "1.0.30000787",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000787.tgz",
+      "integrity": "sha1-ygeigb5Taoi9f6yWuolfPPU/gRs=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -1986,11 +2002,20 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
-    "electron-to-chromium": {
-      "version": "1.3.28",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz",
-      "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4=",
+    "electron-releases": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/electron-releases/-/electron-releases-2.1.0.tgz",
+      "integrity": "sha512-cyKFD1bTE/UgULXfaueIN1k5EPFzs+FRc/rvCY5tIynefAPqopQEgjr0EzY+U3Dqrk/G4m9tXSPuZ77v6dL/Rw==",
       "dev": true
+    },
+    "electron-to-chromium": {
+      "version": "1.3.30",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.30.tgz",
+      "integrity": "sha512-zx1Prv7kYLfc4OA60FhxGbSo4qrEjgSzpo1/37i7l9ltXPYOoQBtjQxY9KmsgfHnBxHlBGXwLlsbt/gub1w5lw==",
+      "dev": true,
+      "requires": {
+        "electron-releases": "2.1.0"
+      }
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -2069,16 +2094,6 @@
             "amdefine": "1.0.1"
           }
         }
-      }
-    },
-    "eslint-plugin-prettier": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.4.0.tgz",
-      "integrity": "sha512-P0EohHM1MwL36GX5l1TOEYyt/5d7hcxrX3CqCjibTN3dH7VCAy2kjsC/WB6dUHnpB4mFkZq1Ndfh2DYQ2QMEGQ==",
-      "dev": true,
-      "requires": {
-        "fast-diff": "1.1.2",
-        "jest-docblock": "21.2.0"
       }
     },
     "esprima": {
@@ -2254,12 +2269,6 @@
         "color-support": "1.1.3",
         "time-stamp": "1.1.0"
       }
-    },
-    "fast-diff": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
-      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -3287,7 +3296,7 @@
       "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
       "dev": true,
       "requires": {
-        "is-ci": "1.0.10",
+        "is-ci": "1.1.0",
         "normalize-path": "1.0.0",
         "strip-indent": "2.0.0"
       },
@@ -3387,7 +3396,7 @@
       "requires": {
         "@dojo/core": "0.3.0",
         "@dojo/has": "0.1.1",
-        "@dojo/interfaces": "0.2.0",
+        "@dojo/interfaces": "0.2.1",
         "@dojo/shim": "0.2.3",
         "@theintern/digdug": "2.0.4",
         "@theintern/leadfoot": "2.0.3",
@@ -3399,9 +3408,9 @@
         "@types/http-errors": "1.5.34",
         "@types/istanbul-lib-coverage": "1.1.0",
         "@types/istanbul-lib-hook": "1.0.0",
-        "@types/istanbul-lib-instrument": "1.7.0",
+        "@types/istanbul-lib-instrument": "1.7.1",
         "@types/istanbul-lib-report": "1.1.0",
-        "@types/istanbul-lib-source-maps": "1.2.0",
+        "@types/istanbul-lib-source-maps": "1.2.1",
         "@types/istanbul-reports": "1.1.0",
         "@types/lodash": "4.14.91",
         "@types/mime-types": "2.1.0",
@@ -3643,9 +3652,9 @@
       }
     },
     "is-ci": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
-      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
         "ci-info": "1.1.2"
@@ -4047,12 +4056,6 @@
         "handlebars": "4.0.11"
       }
     },
-    "jest-docblock": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
-      "dev": true
-    },
     "jest-get-type": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
@@ -4438,7 +4441,7 @@
         "log-update": "1.0.2",
         "ora": "0.2.3",
         "p-map": "1.2.0",
-        "rxjs": "5.5.5",
+        "rxjs": "5.5.6",
         "stream-to-observable": "0.2.0",
         "strip-ansi": "3.0.1"
       },
@@ -4816,9 +4819,9 @@
       }
     },
     "make-error": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
-      "integrity": "sha1-Uq06M5zPEM5itAQLcI/nByRLi5Y=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.2.tgz",
+      "integrity": "sha512-l9ra35l5VWLF24y75Tg8XgfGLX0ueRhph118WKM6H5denx4bB5QF59+4UAm9oJ2qsPQZas/CQUDdtDdfvYHBdQ==",
       "dev": true
     },
     "make-error-cause": {
@@ -4827,7 +4830,7 @@
       "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
       "dev": true,
       "requires": {
-        "make-error": "1.3.0"
+        "make-error": "1.3.2"
       }
     },
     "map-obj": {
@@ -4837,9 +4840,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.7.tgz",
-      "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.9.tgz",
+      "integrity": "sha512-nW5u0dxpXxHfkHzzrveY45gCbi+R4PaO4WRZYqZNl+vB0hVGeqlFn0aOg1c8AKL63TrNFn9Bm2UP4AdiZ9TPLw==",
       "dev": true
     },
     "math-expression-evaluator": {
@@ -5319,10 +5322,13 @@
       "dev": true
     },
     "p-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "dev": true,
+      "requires": {
+        "p-try": "1.0.0"
+      }
     },
     "p-locate": {
       "version": "2.0.0",
@@ -5330,13 +5336,19 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "1.2.0"
       }
     },
     "p-map": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
     "package-json": {
@@ -5988,7 +6000,7 @@
       "integrity": "sha1-Dxk0E3AM8fgr05Bm7wFtZaShgYE=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.14",
+        "postcss": "6.0.15",
         "postcss-media-query-parser": "0.2.3"
       },
       "dependencies": {
@@ -6010,6 +6022,17 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
           }
         },
         "has-flag": {
@@ -6019,14 +6042,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.15",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
+          "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -6036,9 +6059,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -6187,7 +6210,7 @@
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.14"
+        "postcss": "6.0.15"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6208,6 +6231,17 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
           }
         },
         "has-flag": {
@@ -6217,14 +6251,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.15",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
+          "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -6234,9 +6268,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -6251,7 +6285,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.14"
+        "postcss": "6.0.15"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6272,6 +6306,17 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
           }
         },
         "has-flag": {
@@ -6281,14 +6326,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.15",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
+          "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -6298,9 +6343,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -6315,7 +6360,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.14"
+        "postcss": "6.0.15"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6336,6 +6381,17 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
           }
         },
         "has-flag": {
@@ -6345,14 +6401,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.15",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
+          "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -6362,9 +6418,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -6379,7 +6435,7 @@
       "dev": true,
       "requires": {
         "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.14"
+        "postcss": "6.0.15"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6400,6 +6456,17 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
           }
         },
         "has-flag": {
@@ -6409,14 +6476,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.15",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
+          "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -6426,9 +6493,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -7199,9 +7266,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.5.tgz",
-      "integrity": "sha512-D/MfQnPMBk8P8gfwGxvCkuaWBcG58W7dUMT//URPoYzIbDEKT0GezdirkK5whMgKFBATfCoTpxO8bJQGJ04W5A==",
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz",
+      "integrity": "sha512-v4Q5HDC0FHAQ7zcBX7T2IL6O5ltl1a2GX4ENjPXg6SjDY69Cmx9v4113C99a4wGF16ClPv5Z8mghuYorVkg/kg==",
       "dev": true,
       "requires": {
         "symbol-observable": "1.0.1"
@@ -7957,7 +8024,7 @@
         "resolve": "1.5.0",
         "semver": "5.4.1",
         "tslib": "1.8.1",
-        "tsutils": "2.13.1"
+        "tsutils": "2.15.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8031,24 +8098,14 @@
           }
         },
         "tsutils": {
-          "version": "2.13.1",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.13.1.tgz",
-          "integrity": "sha512-XMOEvc2TiYesVSOJMI7OYPnBMSgcvERuGW5Li/J+2A0TuH607BPQnOLQ82oSPZCssB8c9+QGi6qhTBa/f1xQRA==",
+          "version": "2.15.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.15.0.tgz",
+          "integrity": "sha512-kKb1mSqRMwF0GHKya5/hZsI2m7Flg4ONZDeYu4e6Gx+kYAu86zsLNCHcUmNWhCRaUcKshNI272hOzuaCQDzJ2g==",
           "dev": true,
           "requires": {
             "tslib": "1.8.1"
           }
         }
-      }
-    },
-    "tslint-plugin-prettier": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-1.3.0.tgz",
-      "integrity": "sha512-6UqeeV6EABp0RdQkW6eC1vwnAXcKMGJgPeJ5soXiKdSm2vv7c3dp+835CM8pjgx9l4uSa7tICm1Kli+SMsADDg==",
-      "dev": true,
-      "requires": {
-        "eslint-plugin-prettier": "2.4.0",
-        "tslib": "1.8.1"
       }
     },
     "tsutils": {
@@ -9293,7 +9350,7 @@
         "handlebars": "4.0.5",
         "highlight.js": "9.12.0",
         "lodash": "4.17.4",
-        "marked": "0.3.7",
+        "marked": "0.3.9",
         "minimatch": "3.0.4",
         "progress": "1.1.8",
         "shelljs": "0.7.8",

--- a/package.json
+++ b/package.json
@@ -21,20 +21,6 @@
     "prettier": "prettier --write 'src/**/*.ts' 'tests/**/*.ts'",
     "test": "grunt test"
   },
-  "lint-staged": {
-    "*.{ts,tsx}": [
-      "prettier --write",
-      "git add"
-    ]
-  },
-  "prettier": {
-    "singleQuote": true,
-    "tabWidth": 4,
-    "useTabs": true,
-    "parser": "typescript",
-    "printWidth": 120,
-    "arrowParens": "always"
-  },
   "devDependencies": {
     "@dojo/loader": "~0.1.0",
     "@types/glob": "~5.0.0",
@@ -49,7 +35,20 @@
     "prettier": "1.9.2",
     "sinon": "^1.17.4",
     "tslint": "5.8.0",
-    "tslint-plugin-prettier": "1.3.0",
     "typescript": "~2.6.1"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "prettier --write",
+      "git add"
+    ]
+  },
+  "prettier": {
+    "singleQuote": true,
+    "tabWidth": 4,
+    "useTabs": true,
+    "parser": "typescript",
+    "printWidth": 120,
+    "arrowParens": "always"
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,5 @@
 {
-	"rulesDirectory": ["tslint-plugin-prettier"],
 	"rules": {
-		"prettier": true,
 		"align": false,
 		"ban": [],
 		"class-name": true,


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

With the commit hook for formatting typescript files with prettier, having the tslint plugin actually hinders development and basically masks actual linting issues (as people will just ignore the errors until prettier is run or the files are committed).

This change removes the plugin.

References https://github.com/dojo/meta/issues/206